### PR TITLE
Java 25 / WildFly 40 spike — platform libraries version bump + jakarta.xml.bind-api fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [25.104.0-M1] - 2026-06-10
+### Changed
+- Updated parent `cpp-platform-maven-parent-pom` to `25.104.0-M1`
+- Updated `framework.version` (`cp-microservice-framework`) to `25.104.0-M1`
+- Updated `framework-libraries.version` (`cp-framework-libraries`) to `25.104.0-M6`
+- Updated `event-store.version` (`cp-event-store`) to `25.104.0-M1`
+- Updated `file-service.version` (`cp-file-service`) to `25.104.0-M3`
+
 ## [21.0.0-SNAPSHOT] - 2026-04-14
 ### Changed
 - Bumped version to `21.0.0-SNAPSHOT` for Java 21 / WildFly 34 migration

--- a/access-control-parent/access-control-drools/pom.xml
+++ b/access-control-parent/access-control-drools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-parent</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-drools</artifactId>

--- a/access-control-parent/access-control-providers/access-control-assignment-providers/pom.xml
+++ b/access-control-parent/access-control-providers/access-control-assignment-providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-providers</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-assignment-providers</artifactId>
@@ -21,6 +21,11 @@
                         <artifactId>jakarta.jakartaee-api</artifactId>
                         <version>${javaee-api.version}</version>
                         <scope>runtime</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>uk.gov.moj.cpp.assignment</groupId>

--- a/access-control-parent/access-control-providers/access-control-common-providers/pom.xml
+++ b/access-control-parent/access-control-providers/access-control-common-providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-providers</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-common-providers</artifactId>
@@ -38,6 +38,11 @@
                         <artifactId>jakarta.jakartaee-api</artifactId>
                         <version>${javaee-api.version}</version>
                         <scope>runtime</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/access-control-parent/access-control-providers/access-control-hearing-providers/pom.xml
+++ b/access-control-parent/access-control-providers/access-control-hearing-providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-providers</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-hearing-providers</artifactId>
@@ -21,6 +21,11 @@
                         <artifactId>jakarta.jakartaee-api</artifactId>
                         <version>${javaee-api.version}</version>
                         <scope>runtime</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>uk.gov.moj.cpp.hearing</groupId>

--- a/access-control-parent/access-control-providers/access-control-progression-providers/pom.xml
+++ b/access-control-parent/access-control-providers/access-control-progression-providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-providers</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-progression-providers</artifactId>
@@ -21,6 +21,11 @@
                         <artifactId>jakarta.jakartaee-api</artifactId>
                         <version>${javaee-api.version}</version>
                         <scope>runtime</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>uk.gov.moj.cpp.progression</groupId>

--- a/access-control-parent/access-control-providers/access-control-refdata-providers/pom.xml
+++ b/access-control-parent/access-control-providers/access-control-refdata-providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-providers</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-refdata-providers</artifactId>
@@ -25,6 +25,11 @@
                         <artifactId>jakarta.jakartaee-api</artifactId>
                         <version>${javaee-api.version}</version>
                         <scope>runtime</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>uk.gov.moj.cpp.referencedata</groupId>

--- a/access-control-parent/access-control-providers/access-control-sjp-providers/pom.xml
+++ b/access-control-parent/access-control-providers/access-control-sjp-providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-providers</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-sjp-providers</artifactId>
@@ -21,6 +21,11 @@
                         <artifactId>jakarta.jakartaee-api</artifactId>
                         <version>${javaee-api.version}</version>
                         <scope>runtime</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>uk.gov.moj.cpp.sjp</groupId>

--- a/access-control-parent/access-control-providers/pom.xml
+++ b/access-control-parent/access-control-providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-parent</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-providers</artifactId>

--- a/access-control-parent/access-control-test-utils/pom.xml
+++ b/access-control-parent/access-control-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.access-control</groupId>
         <artifactId>access-control-parent</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>access-control-test-utils</artifactId>

--- a/access-control-parent/pom.xml
+++ b/access-control-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.access-control</groupId>

--- a/activiti-parent/activiti-embedded-rest-example/pom.xml
+++ b/activiti-parent/activiti-embedded-rest-example/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>activiti-parent</artifactId>
         <groupId>uk.gov.moj.cpp.activiti</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/activiti-parent/activiti-embedded-rest/pom.xml
+++ b/activiti-parent/activiti-embedded-rest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>activiti-parent</artifactId>
         <groupId>uk.gov.moj.cpp.activiti</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/activiti-parent/pom.xml
+++ b/activiti-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.activiti</groupId>

--- a/audit-library-parent/audit-client/pom.xml
+++ b/audit-library-parent/audit-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>audit-library-parent</artifactId>
         <groupId>uk.gov.moj.cpp.audit</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/audit-library-parent/pom.xml
+++ b/audit-library-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.audit</groupId>

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -22,7 +22,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
 
 variables:
   sonarqubeProject: "uk.gov.moj.platform.libraries:platform-libraries-parent-pom"

--- a/cpp-platform-library-utils/cpp-platform-azure-utils/pom.xml
+++ b/cpp-platform-library-utils/cpp-platform-azure-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common.library.utils</groupId>
         <artifactId>cpp-platform-library-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cpp-platform-library-utils/cpp-platform-data-utils/cpp-platform-data-utils-persistence/pom.xml
+++ b/cpp-platform-library-utils/cpp-platform-data-utils/cpp-platform-data-utils-persistence/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common.library.utils</groupId>
         <artifactId>cpp-platform-data-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>cpp-platform-data-utils-persistence</artifactId>

--- a/cpp-platform-library-utils/cpp-platform-data-utils/cpp-platform-data-utils-rest/pom.xml
+++ b/cpp-platform-library-utils/cpp-platform-data-utils/cpp-platform-data-utils-rest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common.library.utils</groupId>
         <artifactId>cpp-platform-data-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/cpp-platform-library-utils/cpp-platform-data-utils/cpp-platform-data-utils-service/pom.xml
+++ b/cpp-platform-library-utils/cpp-platform-data-utils/cpp-platform-data-utils-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common.library.utils</groupId>
         <artifactId>cpp-platform-data-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>cpp-platform-data-utils-service</artifactId>

--- a/cpp-platform-library-utils/cpp-platform-data-utils/cpp-platform-data-utils-test-utils/pom.xml
+++ b/cpp-platform-library-utils/cpp-platform-data-utils/cpp-platform-data-utils-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common.library.utils</groupId>
         <artifactId>cpp-platform-data-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>cpp-platform-data-utils-test-utils</artifactId>

--- a/cpp-platform-library-utils/cpp-platform-data-utils/pom.xml
+++ b/cpp-platform-library-utils/cpp-platform-data-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common.library.utils</groupId>
         <artifactId>cpp-platform-library-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>cpp-platform-data-utils</artifactId>

--- a/cpp-platform-library-utils/cpp-platform-test-utils/pom.xml
+++ b/cpp-platform-library-utils/cpp-platform-test-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cpp-platform-library-utils</artifactId>
         <groupId>uk.gov.moj.cpp.common.library.utils</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cpp-platform-library-utils/pom.xml
+++ b/cpp-platform-library-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.common.library.utils</groupId>

--- a/feature-control/pom.xml
+++ b/feature-control/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>platform-libraries-parent-pom</artifactId>
         <groupId>uk.gov.moj.platform.libraries</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/healthchecks-parent/pom.xml
+++ b/healthchecks-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.healthchecks</groupId>

--- a/healthchecks-parent/unifiedsearch-healthchecks/pom.xml
+++ b/healthchecks-parent/unifiedsearch-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.healthchecks</groupId>
         <artifactId>healthchecks-parent</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/healthchecks-parent/workmanagement-healthchecks/pom.xml
+++ b/healthchecks-parent/workmanagement-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.healthchecks</groupId>
         <artifactId>healthchecks-parent</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/id-mapper-client/pom.xml
+++ b/id-mapper-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.system.id-mapper</groupId>

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-micrometer</artifactId>

--- a/platform-libraries-bom/pom.xml
+++ b/platform-libraries-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1</version>
     </parent>
 
     <groupId>uk.gov.moj.platform.libraries</groupId>
     <artifactId>platform-libraries-parent-pom</artifactId>
     <name>cpp.platform.libraries</name>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -37,16 +37,20 @@
             2. While release through ADO pipeline, for white listed release branches (main/release-8.x.x) it's done through git hook (legacy solution) via azure pipeline code
             3. While release through ADO pipeline, for branches other than white listed release branches, it's done through versions:set command via azure pipeline code
          -->
-        <cpp.platform-libraries.version>21.0.0-M1-SNAPSHOT</cpp.platform-libraries.version>
+        <cpp.platform-libraries.version>25.104.0-M1-SNAPSHOT</cpp.platform-libraries.version>
+        <!-- 0.8.12 (parent-pom M1) cannot instrument Java 25 class files (major version 69); override until parent-pom M2 -->
+        <plugins.jacoco.version>0.8.14</plugins.jacoco.version>
+        <!-- Pinned to pre-EE9 version: rest-client-generator-plugin uses javax.xml.bind.* (via raml-parser) which is only present in jakarta.xml.bind-api 2.x. DO NOT upgrade. -->
+        <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
 
         <!-- Github libraries versions -->
-        <cpp.common-bom.version>21.0.0-M1-SNAPSHOT</cpp.common-bom.version>
-        <file-service.version>21.0.0-M1-SNAPSHOT</file-service.version>
+        <cpp.common-bom.version>25.104.0-M1</cpp.common-bom.version>
+        <file-service.version>25.104.0-M3</file-service.version>
 
         <!-- Framework versions -->
-        <framework-libraries.version>21.0.0-M1-SNAPSHOT</framework-libraries.version>
-        <framework.version>21.0.0-M1-SNAPSHOT</framework.version>
-        <event-store.version>21.0.0-M1-SNAPSHOT</event-store.version>
+        <framework-libraries.version>25.104.0-M6</framework-libraries.version>
+        <framework.version>25.104.0-M1</framework.version>
+        <event-store.version>25.104.0-M1</event-store.version>
 
         <cpp.framework.version>${framework.version}</cpp.framework.version>
 
@@ -95,21 +99,49 @@
                     <groupId>uk.gov.justice.framework-generators</groupId>
                     <artifactId>direct-client-generator-plugin</artifactId>
                     <version>${framework.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>${jakarta.xml.bind-api.raml.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>uk.gov.justice.framework-generators</groupId>
                     <artifactId>rest-client-generator-plugin</artifactId>
                     <version>${framework.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>${jakarta.xml.bind-api.raml.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>uk.gov.justice.framework-generators</groupId>
                     <artifactId>rest-adapter-generator-plugin</artifactId>
                     <version>${framework.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>${jakarta.xml.bind-api.raml.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>uk.gov.justice.framework-generators</groupId>
                     <artifactId>unifiedsearch-client-generator-plugin</artifactId>
                     <version>${framework.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>${jakarta.xml.bind-api.raml.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>pojo-generation-plugin</artifactId>

--- a/service-components/command/command-api/pom.xml
+++ b/service-components/command/command-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>command</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/command/command-controller/pom.xml
+++ b/service-components/command/command-controller/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>command</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/command/command-handler/pom.xml
+++ b/service-components/command/command-handler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>command</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/command/pom.xml
+++ b/service-components/command/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>service-components</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-components/event/event-api/pom.xml
+++ b/service-components/event/event-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/event/event-indexer/pom.xml
+++ b/service-components/event/event-indexer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-components/event/event-listener/pom.xml
+++ b/service-components/event/event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/event/event-processor/pom.xml
+++ b/service-components/event/event-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/event/pom.xml
+++ b/service-components/event/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>service-components</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-components/pom.xml
+++ b/service-components/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-components/query/pom.xml
+++ b/service-components/query/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>service-components</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-components/query/query-api/pom.xml
+++ b/service-components/query/query-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>query</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/query/query-controller/pom.xml
+++ b/service-components/query/query-controller/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>query</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/query/query-view/pom.xml
+++ b/service-components/query/query-view/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>query</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service-components/service-component-config/pom.xml
+++ b/service-components/service-component-config/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>service-components</artifactId>
         <groupId>uk.gov.moj.cpp.common</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/system-documentgenerator-client/pom.xml
+++ b/system-documentgenerator-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.system.documentgenerator</groupId>

--- a/system-users-library/pom.xml
+++ b/system-users-library/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.common</groupId>

--- a/unifiedsearch-library-parent/pom.xml
+++ b/unifiedsearch-library-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.unifiedsearch</groupId>

--- a/unifiedsearch-library-parent/unifiedsearch-client/pom.xml
+++ b/unifiedsearch-library-parent/unifiedsearch-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearch-library-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearch-library-parent/unifiedsearch-test-utils/pom.xml
+++ b/unifiedsearch-library-parent/unifiedsearch-test-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearch-library-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cpp-platform-libraries

Spike to prove viability of upgrading the CPP platform directly from Java 17 to **Java 25 / WildFly 40 / Jakarta EE 11** (25.104.0-M1-SNAPSHOT).

**Spike gate: cpp-context-users-groups integration tests — 96/96 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Platform libraries: version bump + jakarta.xml.bind-api:2.3.2 added to all generator plugin dependency blocks (rest-client, rest-adapter, messaging-client, unifiedsearch-client); property jakarta.xml.bind-api.raml.version=2.3.2 added

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
https://github.com/hmcts/cpp-framework-java-upgrade-pilot/blob/main/status/25.104.x-status.md