### PR TITLE
Remove wiremock:2.35.2 fat-jar from access-control-test-utils

### DIFF
--- a/access-control-parent/access-control-test-utils/pom.xml
+++ b/access-control-parent/access-control-test-utils/pom.xml
@@ -37,10 +37,6 @@
             <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-        </dependency>
-        <dependency>
             <groupId>uk.gov.justice.services</groupId>
             <artifactId>wiremock-test-utils</artifactId>
         </dependency>


### PR DESCRIPTION
## Summary

- Remove `com.github.tomakehurst:wiremock-jre8-standalone:2.35.2` and `wiremock-webhooks-extension:2.35.2` from `access-control-test-utils`
- These are fat jars that bundle Jackson 2.16.x classes directly onto the classpath
- Jackson 2.16.x's `ObjectMapper` calls `BufferRecycler.releaseToPool()`, which was removed in `jackson-core 2.19+`
- This causes `NoSuchMethodError` at test runtime on any context that depends on `access-control-test-utils` when the 25.104.x BOM resolves `jackson-core:2.21.4`
- `wiremock-test-utils` (already a dep here) transitively provides `org.wiremock:wiremock:3.13.2`, which supplies the same `com.github.tomakehurst.*` API surface under WireMock's backward-compatible package names — no source changes needed

## Test plan

- [ ] CI build passes
- [ ] No `NoSuchMethodError: BufferRecycler.releaseToPool` in downstream context IT tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)